### PR TITLE
Remove the possibility of set a null adapter

### DIFF
--- a/library/ZendOAuth/Client.php
+++ b/library/ZendOAuth/Client.php
@@ -69,31 +69,6 @@ class Client extends HttpClient
     }
 
     /**
-     * Return the current connection adapter
-     *
-     * @return \Zend\Http\Client\Adapter\AdapterInterface|string $adapter
-     */
-    public function getAdapter()
-    {
-        return $this->adapter;
-    }
-
-   /**
-     * Load the connection adapter
-     *
-     * @param \Zend\Http\Client\Adapter\AdapterInterface $adapter
-     * @return void
-     */
-    public function setAdapter($adapter)
-    {
-        if ($adapter == null) {
-            $this->adapter = $adapter;
-        } else {
-              parent::setAdapter($adapter);
-        }
-    }
-
-    /**
      * Set the streamingRequest variable which controls whether we are
      * sending the raw (already encoded) POST data from a stream source.
      *


### PR DESCRIPTION
This code was originally added by @padraic in svn:r22036

> r22036 | padraic | 2010-04-28 20:46:18 +0200 (mié, 28 abr 2010) | 2 lines
> 
> Added streaming data support. The API is identical to that used by Zend_Gdata_HttpClient adding support specifically for Youtube uploads. Please refer to GData reference material (OAuth docs to be updated). Implements ZF-9410

Later get method was removed in svn:r24310 but not synced with GIT version

> r24310 | ramon | 2011-07-30 05:04:50 +0200 (sáb, 30 jul 2011) | 3 lines
> 
> [ZF-10182] Zend_Oauth
> - Fix config http client how object Zend_Config. 

Sincerely I don't see any need of override the methods.
