### PR TITLE
The ->getAdapter() method does not set the adapter if passed in config o...

### DIFF
--- a/library/ZendOAuth/Client.php
+++ b/library/ZendOAuth/Client.php
@@ -75,7 +75,7 @@ class Client extends HttpClient
      */
     public function getAdapter()
     {
-        return $this->adapter;
+        return parent::getAdapter();
     }
 
    /**


### PR DESCRIPTION
This push relates to this issue [https://github.com/zendframework/ZendService_Twitter/pull/18](https://github.com/zendframework/ZendService_Twitter/pull/18)

`->getAdapter()` method of parent class `ZendOAuth\Client` is:

```
public function getAdapter()
{
    if (! $this->adapter) {
        $this->setAdapter($this->config['adapter']);
    }

    return $this->adapter;
}
```

but here was:

```
public function getAdapter()
{
    return $this->adapter;
}
```

replaced with:

```
public function getAdapter()
{
    return parent::getAdapter();
}
```
