### PR TITLE
Fixing malformed 'Content-Type' header.

### DIFF
--- a/library/ZendOAuth/Http/AccessToken.php
+++ b/library/ZendOAuth/Http/AccessToken.php
@@ -109,7 +109,7 @@ class AccessToken extends HTTPClient
         $client->setRawBody(
             $this->_httpUtility->toEncodedQueryString($params)
         );
-        $client->setHeaders(array('ContentType' => Http\Client::ENC_URLENCODED));
+        $client->setHeaders(array('Content-Type' => Http\Client::ENC_URLENCODED));
         return $client;
     }
 


### PR DESCRIPTION
As is mentioned in issues 17 and 19, the Content-Type header is malformed.
https://github.com/zendframework/ZendOAuth/issues/17
https://github.com/zendframework/ZendOAuth/issues/19
